### PR TITLE
Add unit tests for the `UserConfig` object

### DIFF
--- a/tests/test_plist.py
+++ b/tests/test_plist.py
@@ -3,27 +3,44 @@ from dataclasses import dataclass
 from pathlib import Path
 from sqlite3 import Connection, Cursor
 
+import launchd_me
 import pytest
 from launchd_me.plist import LaunchdMeInit, PListDbConnectionManager, UserConfig
 
 
-def test_user_config_initialises_with_correct_attributes():
-    """Initialise UserConfig object correctly.
+class TestAllProjectObjectsInitialiseAsExpected:
+    """Basic tests that ensure all objects initialise as future tests expect.
 
-    Checks all expected attributes are present and there are no unexpected attributes.
+    Newly added classes should be added here.
     """
-    expected_attributes = {
-        "user_name",
-        "user_dir",
-        "project_dir",
-        "plist_dir",
-        "ldm_db_file",
-        "plist_template_path",
-        "launch_agents_dir",
-    }
-    user_config = UserConfig()
-    actual_attributes = set(user_config.__dict__.keys())
-    assert expected_attributes == actual_attributes
+
+    def test_user_config_initialises_with_correct_attributes(self):
+        """Initialise UserConfig object correctly.
+
+        Checks all expected attributes are present and there are no unexpected
+        attributes.
+        """
+        expected_attributes = {
+            "user_name",
+            "user_dir",
+            "project_dir",
+            "plist_dir",
+            "ldm_db_file",
+            "plist_template_path",
+            "launch_agents_dir",
+        }
+        user_config = UserConfig()
+        actual_attributes = set(user_config.__dict__.keys())
+        assert expected_attributes == actual_attributes
+
+    def test_launchd_me_init_initialises_with_correct_attributes(self):
+        """Initialise LaunchdMeInit object correctly.
+
+        Checks all expected attributes are present and there are no unexpected attributes.
+        """
+        user_config = UserConfig()
+        ldm_init = LaunchdMeInit(user_config)
+        assert isinstance(ldm_init._user_config, UserConfig)
 
 
 @dataclass


### PR DESCRIPTION
Fixes #18.

Goes a bit beyond it and suggests a new structure for the tests (testing all objects upfront) which I'm not sure I'm keen on.

I am going to let the structure emerge a bit first before imposing/changing/imposing/changing sucks me into the void. Ref:

- #23  